### PR TITLE
Link `boss requirement option` to `hp% slider` check

### DIFF
--- a/WrathCombo/Combos/PvE/AST/AST.cs
+++ b/WrathCombo/Combos/PvE/AST/AST.cs
@@ -143,10 +143,11 @@ internal static partial class AST
                             return Variant.VariantSpiritDart;
 
                         float refreshTimer = Config.AST_ST_DPS_CombustUptime_Adv ? Config.AST_ST_DPS_CombustUptime_Threshold : 3;
+                        var hpThreshold =
+                            (Config.AST_ST_DPS_CombustSubOption == 0 || !InBossEncounter())
+                                ? Config.AST_DPS_CombustOption : 0;
                         if (GetDebuffRemainingTime(dotDebuffID) <= refreshTimer &&
-                            GetTargetHPPercent() > Config.AST_DPS_CombustOption &&
-                            (Config.AST_ST_DPS_CombustSubOption == 0 ||
-                             Config.AST_ST_DPS_CombustSubOption == 1 && InBossEncounter()))
+                            GetTargetHPPercent() > hpThreshold)
                             return OriginalHook(Combust);
 
                         //Alternate Mode (idles as Malefic)

--- a/WrathCombo/Combos/PvE/AST/AST_Config.cs
+++ b/WrathCombo/Combos/PvE/AST/AST_Config.cs
@@ -1,4 +1,5 @@
-﻿using ImGuiNET;
+﻿using Dalamud.Interface.Colors;
+using ImGuiNET;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Data;
 using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
@@ -75,13 +76,16 @@ internal static partial class AST
                     DrawSliderInt(0, 50, AST_DPS_CombustOption, "Stop using at Enemy HP %. Set to Zero to disable this check.");
 
                     ImGui.Indent();
+
+                    ImGui.TextColored(ImGuiColors.DalamudYellow, "Select what kind of enemies the HP check should be applied to:");
+
+                    DrawHorizontalRadioButton(AST_ST_DPS_CombustSubOption,
+                        "Non-Bosses", "Only applies the HP check above to non-bosses.\nAllows you to only stop DoTing early when it's not a boss.", 0);
                     
                     DrawHorizontalRadioButton(AST_ST_DPS_CombustSubOption,
-                        "All content", $"Uses {ActionWatching.GetActionName(Combust)} logic regardless of content.", 0);
+                        "All Enemies", "Applies the HP check above to all enemies.", 1);
 
-                    DrawHorizontalRadioButton(AST_ST_DPS_CombustSubOption,
-                        "Boss encounters Only", $"Only uses {ActionWatching.GetActionName(Combust)} logic when in Boss encounters.", 1);
-
+                    ImGui.NewLine();
                     ImGui.NewLine();
 
                     DrawRoundedSliderFloat(0, 4, AST_ST_DPS_CombustUptime_Threshold, "Seconds remaining before reapplying the DoT. Set to Zero to disable this check.", digits: 1);


### PR DESCRIPTION
Re: my comments on PunishXIV/WrathCombo#366

This is how you would link the new Boss Requirement option to the hp% slider, to have that option control when the hp% check should apply.
This PR only includes the changes for AST; hopefully a simple enough change though that you could apply it to the other healers, if you're wanting to, but if not let me know.

![image](https://github.com/user-attachments/assets/ab180689-64cd-4f51-9410-1a0d91e60781)