### PR TITLE
AoE optimization for transpose flare line

### DIFF
--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -131,10 +131,27 @@ internal partial class BLM : Caster
                         return Transpose; //Levels 4-34
                 }
 
-                if (ActionReady(Blizzard3) && Gauge.UmbralIceStacks < 3 &&
-                    (HasStatusEffect(Buffs.Triplecast) ||
-                     HasStatusEffect(Role.Buffs.Swiftcast)))
-                    return Blizzard3;
+                if (ActionReady(Blizzard3) && Gauge.UmbralIceStacks < 3)
+                {
+                    if (HasStatusEffect(Buffs.Triplecast) || HasStatusEffect(Role.Buffs.Swiftcast))
+                        return Blizzard3;
+                    
+                    if (CanWeave() && ActionReady(Role.Swiftcast) && !HasStatusEffect(Buffs.Triplecast))
+                        return Role.Swiftcast;
+
+                    if (CanWeave() && ActionReady(Triplecast) &&
+                        !HasStatusEffect(Buffs.Triplecast) &&
+                        !HasStatusEffect(Role.Buffs.Swiftcast))
+                        return Triplecast;
+                    
+                    if (HasPolyglotStacks())
+                        return LevelChecked(Xenoglossy)
+                            ? Xenoglossy
+                            : Foul;
+                    
+                    if (Gauge.IsParadoxActive)
+                        return Paradox;
+                }
 
                 if (ActionReady(BlizzardSpam))
                     return BlizzardSpam;
@@ -312,9 +329,30 @@ internal partial class BLM : Caster
                         return Transpose; //Levels 4-34
                 }
 
-                if (ActionReady(Blizzard3) && Gauge.UmbralIceStacks < 3 &&
-                    (HasStatusEffect(Buffs.Triplecast) || HasStatusEffect(Role.Buffs.Swiftcast)))
-                    return Blizzard3;
+                if (ActionReady(Blizzard3) && Gauge.UmbralIceStacks < 3)
+                {
+                    if (HasStatusEffect(Buffs.Triplecast) || HasStatusEffect(Role.Buffs.Swiftcast))
+                        return Blizzard3;
+                    
+                    if (CanWeave() && IsEnabled(CustomComboPreset.BLM_ST_Swiftcast) &&
+                        ActionReady(Role.Swiftcast) && !HasStatusEffect(Buffs.Triplecast))
+                        return Role.Swiftcast;
+
+                    if (CanWeave() && IsEnabled(CustomComboPreset.BLM_ST_Triplecast) && 
+                        ActionReady(Triplecast) &&
+                        !HasStatusEffect(Buffs.Triplecast) &&
+                        !HasStatusEffect(Role.Buffs.Swiftcast))
+                        return Triplecast;
+                    
+                    if (IsEnabled(CustomComboPreset.BLM_ST_UsePolyglot) &&
+                        HasPolyglotStacks())
+                        return LevelChecked(Xenoglossy)
+                            ? Xenoglossy
+                            : Foul;
+                    
+                    if (Gauge.IsParadoxActive)
+                        return Paradox;
+                }
 
                 if (ActionReady(BlizzardSpam))
                     return BlizzardSpam;

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -486,7 +486,7 @@ internal partial class BLM : Caster
                 if (FlarestarReady)
                     return FlareStar;
 
-                if (!LevelChecked(Flare) && ActionReady(Fire2) &&
+                if (ActionReady(Fire2) &&
                     !TraitLevelChecked(Traits.EnhancedAstralFire) &&
                     (TraitLevelChecked(Traits.UmbralHeart) && Gauge.UmbralHearts > 1 || !TraitLevelChecked(Traits.UmbralHeart)))
                     return OriginalHook(Fire2);

--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -486,7 +486,7 @@ internal partial class BLM : Caster
                 if (FlarestarReady)
                     return FlareStar;
 
-                if (ActionReady(Fire2) &&
+                if (!LevelChecked(Flare) && ActionReady(Fire2) &&
                     !TraitLevelChecked(Traits.EnhancedAstralFire) &&
                     (TraitLevelChecked(Traits.UmbralHeart) && Gauge.UmbralHearts > 1 || !TraitLevelChecked(Traits.UmbralHeart)))
                     return OriginalHook(Fire2);
@@ -500,7 +500,7 @@ internal partial class BLM : Caster
                 if (ActionReady(Flare))
                     return Flare;
 
-                if (ActionReady(Blizzard2) && TraitLevelChecked(Traits.AspectMasteryIII))
+                if (IsNotEnabled(CustomComboPreset.BLM_AoE_Transpose) && ActionReady(Blizzard2) && TraitLevelChecked(Traits.AspectMasteryIII))
                     return OriginalHook(Blizzard2);
 
                 if (IsEnabled(CustomComboPreset.BLM_AoE_Transpose) &&
@@ -512,7 +512,7 @@ internal partial class BLM : Caster
             {
                 if ((CurMp == MP.MaxMP || TraitLevelChecked(Traits.EnhancedAstralFire)) && HasMaxUmbralHeartStacks)
                 {
-                    if (ActionReady(Fire2) && TraitLevelChecked(Traits.AspectMasteryIII))
+                    if (IsNotEnabled(CustomComboPreset.BLM_AoE_Transpose) && ActionReady(Fire2) && TraitLevelChecked(Traits.AspectMasteryIII))
                         return OriginalHook(Fire2);
 
                     if (IsEnabled(CustomComboPreset.BLM_AoE_Transpose) &&


### PR DESCRIPTION
Hi, it's me again.

I made some changes to the AoE portion of the code in advance aoe. Essentially, once you have Flare, you never want to use high fire 2 or high bliz 2 ever again. They are very low potency and it is better to simply clip transpose then to cast either of these 2 spells.