### PR TITLE
sage stuff

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -5576,6 +5576,26 @@ public enum CustomComboPreset
     [ParentCombo(SGE_ST_Heal)]
     [CustomComboInfo("Pepsis Option", "Triggers Pepsis if a shield is present.", SGE.JobID)]
     SGE_ST_Heal_Pepsis = 14020,
+    
+    [ParentCombo(SGE_ST_Heal)]
+    [CustomComboInfo("Physis Option", "Adds Physis.", SGE.JobID)]
+    [PossiblyRetargeted]
+    SGE_ST_Heal_Physis = 14065,
+    
+    [ParentCombo(SGE_ST_Heal)]
+    [CustomComboInfo("Kerachole Option", "Adds Kerachole.", SGE.JobID)]
+    [PossiblyRetargeted]
+    SGE_ST_Heal_Kerachole = 14066,
+    
+    [ParentCombo(SGE_ST_Heal)]
+    [CustomComboInfo("Holos Option", "Adds Holos.", SGE.JobID)]
+    [PossiblyRetargeted]
+    SGE_ST_Heal_Holos = 14067,
+    
+    [ParentCombo(SGE_ST_Heal)]
+    [CustomComboInfo("Panhaima Option", "Adds Panhaima.", SGE.JobID)]
+    [PossiblyRetargeted]
+    SGE_ST_Heal_Panhaima = 14068,
 
     #endregion
 
@@ -5708,8 +5728,30 @@ public enum CustomComboPreset
     SGE_DPS_Variant_Rampart = 14049,
 
     #endregion
+    
+    #region Hidden Features
+    [CustomComboInfo("Hidden Options", "Collection of cheeky or encounter-specific extra options only available to those in the know.\nDo not expect these options to be maintained, or even kept, after they are no longer Current.", SGE.JobID)]
+    [Hidden]
+    SGE_Hidden = 14069,
+    
+    [ParentCombo(SGE_Hidden)]
+    [CustomComboInfo("Eukrasian Prognosis Option", "Will try to cast Shields when a raidwide casting is detected if shieldcheck from Eukrasian Prognosis setting passes. \nWill be used in all 4 main combos.", SGE.JobID)]
+    [Hidden]
+    SGE_Hidden_EPrognosis = 14070,
+    
+    [ParentCombo(SGE_Hidden)]
+    [CustomComboInfo("Kerachole Option", "Will try to cast Kerachole when a raidwide casting is detected. \nWill be used in all 4 main combos.", SGE.JobID)]
+    [Hidden]
+    SGE_Hidden_Kerachole = 14071,
+    
+    [ParentCombo(SGE_Hidden)]
+    [CustomComboInfo("Holos Option", "Will try to cast Holos when a raidwide casting is detected. \nWill be used in all 4 main combos.", SGE.JobID)]
+    [Hidden]
+    SGE_Hidden_Holos = 14072,
+    
+    #endregion
 
-    // Last used number = 14064
+    // Last used number = 14068
 
     #endregion
 

--- a/WrathCombo/Combos/PvE/SGE/SGE.cs
+++ b/WrathCombo/Combos/PvE/SGE/SGE.cs
@@ -40,6 +40,17 @@ internal partial class SGE : Healer
             //Occult skills
             if (OccultCrescent.ShouldUsePhantomActions())
                 return OccultCrescent.BestPhantomAction();
+            
+            #region Hidden Feature Raidwide
+
+            if (HiddenKerachole())
+                return Kerachole;
+            if (HiddenHolos())
+                return Holos;
+            if (HiddenEprognosis())
+                return HasStatusEffect(Buffs.Eukrasia) ? OriginalHook(Prognosis) : Eukrasia;
+           
+            #endregion
 
             if (CanSpellWeave() && !HasDoubleWeaved() && !HasStatusEffect(Buffs.Eukrasia))
             {
@@ -142,6 +153,17 @@ internal partial class SGE : Healer
             //Occult skills
             if (OccultCrescent.ShouldUsePhantomActions())
                 return OccultCrescent.BestPhantomAction();
+            
+            #region Hidden Feature Raidwide
+
+            if (HiddenKerachole())
+                return Kerachole;
+            if (HiddenHolos())
+                return Holos;
+            if (HiddenEprognosis())
+                return HasStatusEffect(Buffs.Eukrasia) ? OriginalHook(Prognosis) : Eukrasia;
+           
+            #endregion
 
             if (CanSpellWeave() && !HasDoubleWeaved())
             {
@@ -225,6 +247,17 @@ internal partial class SGE : Healer
 
             if (actionID is not Diagnosis)
                 return actionID;
+            
+            #region Hidden Feature Raidwide
+
+            if (HiddenKerachole())
+                return Kerachole;
+            if (HiddenHolos())
+                return Holos;
+            if (HiddenEprognosis())
+                return HasStatusEffect(Buffs.Eukrasia) ? OriginalHook(Prognosis) : Eukrasia;
+           
+            #endregion
 
             if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Esuna) &&
                 ActionReady(Role.Esuna) &&
@@ -278,6 +311,17 @@ internal partial class SGE : Healer
         {
             if (actionID is not Prognosis)
                 return actionID;
+            
+            #region Hidden Feature Raidwide
+
+            if (HiddenKerachole())
+                return Kerachole;
+            if (HiddenHolos())
+                return Holos;
+            if (HiddenEprognosis())
+                return HasStatusEffect(Buffs.Eukrasia) ? OriginalHook(Prognosis) : Eukrasia;
+           
+            #endregion
 
             //Zoe -> Pneuma like Eukrasia 
             if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_ZoePneuma) &&

--- a/WrathCombo/Combos/PvE/SGE/SGE_Config.cs
+++ b/WrathCombo/Combos/PvE/SGE/SGE_Config.cs
@@ -138,49 +138,49 @@ internal partial class SGE
                     DrawSliderInt(0, 100, SGE_ST_Heal_Soteria,
                         "Start using when below HP %. Set to 100 to disable this check.");
                     DrawPriorityInput(SGE_ST_Heals_Priority,
-                        8, 0, $"{Soteria.ActionName()} Priority: ");
+                        12, 0, $"{Soteria.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SGE_ST_Heal_Zoe:
                     DrawSliderInt(0, 100, SGE_ST_Heal_Zoe,
                         "Start using when below HP %. Set to 100 to disable this check.");
                     DrawPriorityInput(SGE_ST_Heals_Priority,
-                        8, 1, $"{Zoe.ActionName()} Priority: ");
+                        12, 1, $"{Zoe.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SGE_ST_Heal_Pepsis:
                     DrawSliderInt(0, 100, SGE_ST_Heal_Pepsis,
                         "Start using when below HP %. Set to 100 to disable this check.");
                     DrawPriorityInput(SGE_ST_Heals_Priority,
-                        8, 2, $"{Pepsis.ActionName()} Priority: ");
+                        12, 2, $"{Pepsis.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SGE_ST_Heal_Taurochole:
                     DrawSliderInt(0, 100, SGE_ST_Heal_Taurochole,
                         "Start using when below HP %. Set to 100 to disable this check.");
                     DrawPriorityInput(SGE_ST_Heals_Priority,
-                        8, 3, $"{Taurochole.ActionName()} Priority: ");
+                        12, 3, $"{Taurochole.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SGE_ST_Heal_Haima:
                     DrawSliderInt(0, 100, SGE_ST_Heal_Haima,
                         "Start using when below HP %. Set to 100 to disable this check.");
                     DrawPriorityInput(SGE_ST_Heals_Priority,
-                        8, 4, $"{Haima.ActionName()} Priority: ");
+                        12, 4, $"{Haima.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SGE_ST_Heal_Krasis:
                     DrawSliderInt(0, 100, SGE_ST_Heal_Krasis,
                         "Start using when below HP %. Set to 100 to disable this check.");
                     DrawPriorityInput(SGE_ST_Heals_Priority,
-                        8, 5, $"{Krasis.ActionName()} Priority: ");
+                        12, 5, $"{Krasis.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SGE_ST_Heal_Druochole:
                     DrawSliderInt(0, 100, SGE_ST_Heal_Druochole,
                         "Start using when below HP %. Set to 100 to disable this check.");
                     DrawPriorityInput(SGE_ST_Heals_Priority,
-                        8, 6, $"{Druochole.ActionName()} Priority: ");
+                        12, 6, $"{Druochole.ActionName()} Priority: ");
                     break;
 
                 case CustomComboPreset.SGE_ST_Heal_EDiagnosis:
@@ -190,9 +190,33 @@ internal partial class SGE
                         "Sage Shield Check", "Enable to not override an existing Sage's shield.", 2, 0);
                     DrawHorizontalMultiChoice(SGE_ST_Heal_EDiagnosisOpts,
                         "Scholar Shield Check", "Enable to not override an existing Scholar's shield.", 2, 1);
-                    DrawPriorityInput(SGE_ST_Heals_Priority, 8, 7, $"{EukrasianDiagnosis.ActionName()} Priority: ");
+                    DrawPriorityInput(SGE_ST_Heals_Priority, 12, 7, $"{EukrasianDiagnosis.ActionName()} Priority: ");
+                    break;
+                
+                case CustomComboPreset.SGE_ST_Heal_Kerachole:
+                    DrawSliderInt(0, 100, SGE_ST_Heal_KeracholeHP, "Start using when below HP %. Set to 100 to disable this check");
+                    DrawAdditionalBoolChoice(SGE_ST_Heal_KeracholeBossOption, "Not on Bosses", "Will not use on ST in Boss encounters.");
+                    DrawPriorityInput(SGE_ST_Heals_Priority, 12, 8, $"{Kerachole.ActionName()} Priority: ");
                     break;
 
+                case CustomComboPreset.SGE_ST_Heal_Physis:
+                    DrawSliderInt(0, 100, SGE_ST_Heal_PhysisHP, "Start using when below HP %. Set to 100 to disable this check");
+                    DrawAdditionalBoolChoice(SGE_ST_Heal_PhysisBossOption, "Not on Bosses", "Will not use on ST in Boss encounters.");
+                    DrawPriorityInput(SGE_ST_Heals_Priority, 12, 9, $"{Physis.ActionName()} Priority: ");
+                    break;
+                
+                case CustomComboPreset.SGE_ST_Heal_Panhaima:
+                    DrawSliderInt(0, 100, SGE_ST_Heal_PanhaimaHP, "Start using when below HP %. Set to 100 to disable this check");
+                    DrawAdditionalBoolChoice(SGE_ST_Heal_PanhaimaBossOption, "Not on Bosses", "Will not use on ST in Boss encounters.");
+                    DrawPriorityInput(SGE_ST_Heals_Priority, 12, 10, $"{Panhaima.ActionName()} Priority: ");
+                    break;
+                
+                case CustomComboPreset.SGE_ST_Heal_Holos:
+                    DrawSliderInt(0, 100, SGE_ST_Heal_HolosHP, "Start using when below HP %. Set to 100 to disable this check");
+                    DrawAdditionalBoolChoice(SGE_ST_Heal_HolosBossOption, "Not on Bosses", "Will not use on ST in Boss encounters.");
+                    DrawPriorityInput(SGE_ST_Heals_Priority, 12, 11, $"{Holos.ActionName()} Priority: ");
+                    break;
+                
                 case CustomComboPreset.SGE_AoE_Heal_Lucid:
                     DrawSliderInt(4000, 9500, SGE_AoE_Heal_LucidOption, "MP Threshold", 150, Hundreds);
                     break;
@@ -270,6 +294,11 @@ internal partial class SGE
                     DrawRadioButton(SGE_Eukrasia_Mode, $"{EukrasianPrognosis.ActionName()}", "", 2);
                     DrawRadioButton(SGE_Eukrasia_Mode, $"{EukrasianDyskrasia.ActionName()}", "", 3);
                     break;
+                
+                case CustomComboPreset.SGE_Hidden_Holos:
+                    DrawSliderInt(0, 100, SGE_Hidden_HolosOption,
+                        "Start using when below party average HP % to not waste the heal portion if desired. Set to 100 to disable this check");
+                    break;
 
                 #endregion
             }
@@ -307,6 +336,10 @@ internal partial class SGE
         public static UserBool
             SGE_ST_Heal_Adv = new("SGE_ST_Heal_Adv"),
             SGE_ST_Heal_IncludeShields = new("SGE_ST_Heal_IncludeShields"),
+            SGE_ST_Heal_KeracholeBossOption = new("SGE_ST_Heal_KeracholeBossOption"),
+            SGE_ST_Heal_PanhaimaBossOption = new("SGE_ST_Heal_PanhaimaBossOption"),
+            SGE_ST_Heal_PhysisBossOption = new("SGE_ST_Heal_PhysisBossOption"),
+            SGE_ST_Heal_HolosBossOption = new("SGE_ST_Heal_HolosBossOption"),
             SGE_AoE_Heal_KeracholeTrait = new("SGE_AoE_Heal_KeracholeTrait");
         public static UserInt
             SGE_ST_Heal_LucidOption = new("SGE_ST_Heal_LucidOption", 6500),
@@ -318,6 +351,10 @@ internal partial class SGE
             SGE_ST_Heal_EDiagnosisHP = new("SGE_ST_Heal_EDiagnosisHP", 75),
             SGE_ST_Heal_Druochole = new("SGE_ST_Heal_Druochole", 70),
             SGE_ST_Heal_Taurochole = new("SGE_ST_Heal_Taurochole", 60),
+            SGE_ST_Heal_KeracholeHP = new("SGE_ST_Heal_KeracholeHP", 70),
+            SGE_ST_Heal_PhysisHP = new("SGE_ST_Heal_PhysisHP", 70),
+            SGE_ST_Heal_PanhaimaHP = new("SGE_ST_Heal_PanhaimaHP", 70),
+            SGE_ST_Heal_HolosHP = new("SGE_ST_Heal_HolosHP", 70),
             SGE_ST_Heal_Esuna = new("SGE_ST_Heal_Esuna", 50),
             SGE_AoE_Heal_LucidOption = new("SGE_AoE_Heal_LucidOption", 6500),
             SGE_AoE_Heal_ZoeOption = new("SGE_AoE_Heal_PneumaOption", 50),
@@ -328,7 +365,8 @@ internal partial class SGE
             SGE_AoE_Heal_KeracholeOption = new("SGE_AoE_Heal_KeracholeOption", 75),
             SGE_AoE_Heal_IxocholeOption = new("SGE_AoE_Heal_IxocholeOption", 70),
             SGE_AoE_Heal_HolosOption = new("SGE_AoE_Heal_HolosOption", 60),
-            SGE_AoE_Heal_EPrognosisOption = new("SGE_AoE_Heal_EPrognosisOption", 75);
+            SGE_AoE_Heal_EPrognosisOption = new("SGE_AoE_Heal_EPrognosisOption", 75),
+            SGE_Hidden_HolosOption = new("SGE_Hidden_HolosOption", 70);
         public static UserIntArray
             SGE_ST_Heals_Priority = new("SGE_ST_Heals_Priority"),
             SGE_AoE_Heals_Priority = new("SGE_AoE_Heals_Priority");

--- a/WrathCombo/Combos/PvE/SGE/SGE_Helper.cs
+++ b/WrathCombo/Combos/PvE/SGE/SGE_Helper.cs
@@ -28,6 +28,25 @@ internal partial class SGE
         Addersting > 0;
 
     #region Healing
+    
+    #region Hidden Raidwides
+    internal static bool HiddenKerachole()
+    {
+        return IsEnabled(CustomComboPreset.SGE_Hidden_Kerachole) && ActionReady(Kerachole) && HasAddersgall() && CanSpellWeave() && RaidWideCasting();
+    }
+    internal static bool HiddenHolos()
+    {
+        return IsEnabled(CustomComboPreset.SGE_Hidden_Holos) && ActionReady(Holos) && CanSpellWeave() && RaidWideCasting() &&
+               GetPartyAvgHPPercent() <= SGE_Hidden_HolosOption;
+    }
+    internal static bool HiddenEprognosis()
+    {
+        bool shieldCheck = GetPartyBuffPercent(Buffs.EukrasianPrognosis) <= SGE_AoE_Heal_EPrognosisOption &&
+                           GetPartyBuffPercent(SCH.Buffs.Galvanize) <= SGE_AoE_Heal_EPrognosisOption;
+        
+        return IsEnabled(CustomComboPreset.SGE_Hidden_EPrognosis) && shieldCheck && RaidWideCasting();
+    }
+    #endregion
 
     #region ST
 
@@ -47,13 +66,11 @@ internal partial class SGE
             case 0:
                 action = Soteria;
                 enabled = IsEnabled(CustomComboPreset.SGE_ST_Heal_Soteria);
-
                 return SGE_ST_Heal_Soteria;
 
             case 1:
                 action = Zoe;
                 enabled = IsEnabled(CustomComboPreset.SGE_ST_Heal_Zoe);
-
                 return SGE_ST_Heal_Zoe;
 
             case 2:
@@ -61,31 +78,26 @@ internal partial class SGE
 
                 enabled = IsEnabled(CustomComboPreset.SGE_ST_Heal_Pepsis) &&
                           HasStatusEffect(Buffs.EukrasianDiagnosis, healTarget);
-
                 return SGE_ST_Heal_Pepsis;
 
             case 3:
                 action = Taurochole;
                 enabled = IsEnabled(CustomComboPreset.SGE_ST_Heal_Taurochole) && HasAddersgall();
-
                 return SGE_ST_Heal_Taurochole;
 
             case 4:
                 action = Haima;
                 enabled = IsEnabled(CustomComboPreset.SGE_ST_Heal_Haima);
-
                 return SGE_ST_Heal_Haima;
 
             case 5:
                 action = Krasis;
                 enabled = IsEnabled(CustomComboPreset.SGE_ST_Heal_Krasis);
-
                 return SGE_ST_Heal_Krasis;
 
             case 6:
                 action = Druochole;
                 enabled = IsEnabled(CustomComboPreset.SGE_ST_Heal_Druochole) && HasAddersgall();
-
                 return SGE_ST_Heal_Druochole;
 
             case 7:
@@ -93,8 +105,31 @@ internal partial class SGE
                 enabled = IsEnabled(CustomComboPreset.SGE_ST_Heal_EDiagnosis) &&
                           GetTargetHPPercent(healTarget, SGE_ST_Heal_IncludeShields) <= SGE_ST_Heal_EDiagnosisHP &&
                           shieldCheck && scholarShieldCheck;
-
                 return SGE_ST_Heal_EDiagnosisHP;
+            
+            case 8:
+                action = Kerachole;
+                enabled = IsEnabled(CustomComboPreset.SGE_ST_Heal_Kerachole) && HasAddersgall() && 
+                          (!SGE_ST_Heal_KeracholeBossOption || !InBossEncounter());
+                return SGE_ST_Heal_KeracholeHP;
+            
+            case 9:
+                action = OriginalHook(Physis);
+                enabled = IsEnabled(CustomComboPreset.SGE_ST_Heal_Physis) && 
+                          (!SGE_ST_Heal_PhysisBossOption || !InBossEncounter());
+                return SGE_ST_Heal_PhysisHP;
+            
+            case 10:
+                action = Panhaima;
+                enabled = IsEnabled(CustomComboPreset.SGE_ST_Heal_Panhaima) && 
+                          (!SGE_ST_Heal_PanhaimaBossOption|| !InBossEncounter());
+                return SGE_ST_Heal_PanhaimaHP;
+            
+            case 11:
+                action = Holos;
+                enabled = IsEnabled(CustomComboPreset.SGE_ST_Heal_Holos) && 
+                          (!SGE_ST_Heal_HolosBossOption || !InBossEncounter());
+                return SGE_ST_Heal_HolosHP;
         }
 
         enabled = false;
@@ -104,7 +139,7 @@ internal partial class SGE
     }
 
     #endregion
-
+    
     #region AoE
 
     internal static int GetMatchingConfigAoE(int i, out uint action, out bool enabled)


### PR DESCRIPTION
- added to st with boss only option
- physis
- kerachole did not do a trait check bc the 10% dr is still useful in this case. 
- panhaima
- holos
-  added hidden raidwide options
- kerachole weave only
- holos, has a health slider in case people wanna not waste the 300 potency heal weave only
- eprognosis attached the the aoe healing slider for shield checking just like succor version

ran a couple dungeons with it. seems super solid. sage > sch any day tbh. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new single-target healing options for Sage, including Kerachole, Physis, Panhaima, and Holos, each with customizable HP thresholds and boss usage settings.
  * Introduced hidden healing actions for specialized encounter use, such as Eukrasian Prognosis, Kerachole, and Holos.
* **Enhancements**
  * Improved configuration interface with expanded priority and threshold settings for healing actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->