### PR TITLE
Allows Last Lash with no target

### DIFF
--- a/WrathCombo/Combos/PvE/VPR/VPR.cs
+++ b/WrathCombo/Combos/PvE/VPR/VPR.cs
@@ -430,8 +430,7 @@ internal partial class VPR : Melee
             {
                 // Death Rattle / Legacy Weaves
                 if (LevelChecked(SerpentsTail) &&
-                    OriginalHook(SerpentsTail) is not SerpentsTail &&
-                    InActionRange(OriginalHook(SerpentsTail)))
+                    OriginalHook(SerpentsTail) is not SerpentsTail)
                     return OriginalHook(SerpentsTail);
 
                 // Uncoiled combo
@@ -577,8 +576,7 @@ internal partial class VPR : Melee
                 // Death Rattle / Legacy Weaves
                 if (IsEnabled(CustomComboPreset.VPR_AoE_SerpentsTail) &&
                     LevelChecked(SerpentsTail) &&
-                    OriginalHook(SerpentsTail) is not SerpentsTail &&
-                    InActionRange(OriginalHook(SerpentsTail)))
+                    OriginalHook(SerpentsTail) is not SerpentsTail)
                     return OriginalHook(SerpentsTail);
 
                 // Uncoiled combo


### PR DESCRIPTION
Allows Last Lash OGCD to fire even without a target incase the target dies right before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the responsiveness of certain actions related to "Death Rattle / Legacy Weaves" by removing unnecessary range checks. This may result in smoother or more consistent behavior during specific combo sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->