### PR TITLE
Fix BLM_B4toDespair

### DIFF
--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -771,17 +771,34 @@ internal partial class BLM : Caster
     internal class BLM_Blizzard4toDespair : CustomCombo
     {
         protected internal override Preset Preset => Preset.BLM_Blizzard4toDespair;
+
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is not (Blizzard3 or Blizzard4))
-                return actionID;
+            // Only transform the spell chosen in config, not both
+            if (BLM_B4toDespair == 0)
+            {
+                if (actionID is not Blizzard4)
+                    return actionID;
 
-            return BLM_B4toDespair == 0 && FirePhase && LevelChecked(Despair) && CurMp >= 800 ||
-                   BLM_B4toDespair == 1 && FirePhase && LevelChecked(Despair) && CurMp >= 800
-                ? Despair
-                : actionID;
+                return FirePhase && LevelChecked(Despair) && CurMp >= 800
+                    ? Despair
+                    : actionID;
+            }
+
+            if (BLM_B4toDespair == 1)
+            {
+                if (actionID is not Blizzard3)
+                    return actionID;
+
+                return FirePhase && LevelChecked(Despair) && CurMp >= 800
+                    ? Despair
+                    : actionID;
+            }
+
+            return actionID;
         }
     }
+
 
     internal class BLM_Fire1Despair : CustomCombo
     {


### PR DESCRIPTION
Fix BLM_B4toDespair, currently changes both blizzard 4 and 3 regardless of option

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Despair auto-transform now applies only to the Blizzard spell you select in settings, preventing unintended transformations.
  - Previously, both Blizzard III and Blizzard IV could transform regardless of your choice; this is now corrected.
  - Existing requirements (being in Fire phase, Despair unlocked, and sufficient MP) remain unchanged, improving reliability and predictability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->