### PR TITLE
Update Umbral Heart Check Adv AOE

### DIFF
--- a/WrathCombo/Combos/PvE/BLM/BLM.cs
+++ b/WrathCombo/Combos/PvE/BLM/BLM.cs
@@ -621,7 +621,7 @@ internal partial class BLM : Caster
             if (IcePhase)
             {
                 if (HasMaxUmbralHeartStacks ||
-                    MP.Cur >= 5000 && LevelChecked(Flare) ||
+                    MP.Cur >= 5000 && LevelChecked(Flare) && !TraitLevelChecked(Traits.UmbralHeart)||
                     MP.Full && !LevelChecked(Flare))
                 {
                     if (IsEnabled(Preset.BLM_AoE_Transpose) &&


### PR DESCRIPTION
Umbral Heart was not checking if it had stacks at mp > 5000 resulting in only 1 flare being cast.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed Black Mage Advanced AoE mode to prevent incorrect ability selections during Ice-phase rotations when specific player traits are active, improving combat rotation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->