### PR TITLE
Performance: reduce per-frame and per-hook allocations

### DIFF
--- a/WrathCombo/Attributes/SettingAttributes.cs
+++ b/WrathCombo/Attributes/SettingAttributes.cs
@@ -81,10 +81,6 @@ public class Setting(
         Stack,
     }
     
-    internal string Name { get; }
-    internal string HelpMark { get; } 
-    internal string RecommendedValue { get; } 
-    internal string DefaultValue { get; } 
     internal string? UnitLabel { get; }
     internal Type TheType { get; } = type;
     internal string? ExtraHelpMark { get; }

--- a/WrathCombo/AutoRotation/AutoRotationConfigIPCWrapper.cs
+++ b/WrathCombo/AutoRotation/AutoRotationConfigIPCWrapper.cs
@@ -51,9 +51,9 @@ public class AutoRotationConfigIPCWrapper(AutoRotationConfig? config)
         }
     }
 
-    public DPSSettingsIPCWrapper DPSSettings => new(config.DPSSettings);
+    public DPSSettingsIPCWrapper DPSSettings => field ??= new(config.DPSSettings);
 
-    public HealerSettingsIPCWrapper HealerSettings => new(config.HealerSettings);
+    public HealerSettingsIPCWrapper HealerSettings => field ??= new(config.HealerSettings);
 
     public bool OrbwalkerIntegration
     {

--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -48,7 +48,8 @@ internal unsafe class AutoRotationController
 
     public static bool WouldLikeToGroundTarget;
     public static bool Paused;
-    public static int UnpauseSeconds;
+    // Placeholder for the unimplemented territory-warning auto-pause feature in ScanForWarnings.
+    public static int UnpauseSeconds = 0;
 
     public static IGameObject? AutorotHealTarget;
     public static bool AutorotRaidwiding;
@@ -73,7 +74,6 @@ internal unsafe class AutoRotationController
             return;
 
         bool pauseWarningFound = false;
-        bool raidwideWarningFound = false;
         var logMessages = Svc.Data.Excel.GetSheet<LogMessage>();
         switch (Content.TerritoryID)
         {
@@ -136,6 +136,18 @@ internal unsafe class AutoRotationController
 
     static bool CombatBypass => DPSTargeting.BaseSelection.Any(x => (cfg.BypassQuest && IsQuestMob(x)) || (cfg.BypassFATE && x.Struct()->FateId != 0 && InFATE()));
     static bool NotInCombat => !GetPartyMembers().Any(x => x.BattleChara is not null && x.BattleChara.Struct()->InCombat && !x.IsOutOfPartyNPC) || PartyEngageDuration().TotalSeconds < cfg.CombatDelay;
+
+    private static bool AnyHostileWithinRangeOf(IGameObject? referenceTarget, float range)
+    {
+        if (referenceTarget is null) return false;
+        foreach (var x in Svc.Objects)
+        {
+            if (x.IsDead || !x.IsTargetable || !x.IsHostile()) continue;
+            if (GetTargetDistance(x, referenceTarget) <= range)
+                return true;
+        }
+        return false;
+    }
 
     private static bool ShouldSkipAutorotation()
     {
@@ -371,19 +383,43 @@ internal unsafe class AutoRotationController
         }
     }
 
+    private static readonly List<PresetStorage.PresetData> _processAoEScratch = new();
+    private static readonly List<PresetStorage.PresetData> _processSTScratch = new();
+
     private static bool ProcessAutoActions(Dictionary<Preset, bool> autoActions, ref uint _, bool canHeal, bool stOnly)
     {
-        // Pre-filter and cache attributes to avoid repeated lookups
-        var filteredActions = autoActions
-            .Select(x => new { Preset = x.Key, Attributes = x.Key.Attributes() })
-            .Where(x => x.Attributes is { AutoAction: not null, ReplaceSkill: not null })
-            .Where(x => x.Attributes.AutoAction.IsHeal == canHeal)
-            .Where(x => !stOnly || x.Attributes.AutoAction.IsAoE == false)
-            .OrderByDescending(x => x.Attributes.AutoAction.IsAoE);
+        _processAoEScratch.Clear();
+        _processSTScratch.Clear();
 
-        foreach (var entry in filteredActions)
+        // Single-pass filter + partition into AoE-first / ST-after (mirrors OrderByDescending(IsAoE))
+        foreach (var preset in autoActions.Keys)
         {
-            var attributes = entry.Attributes;
+            var attr = preset.Attributes();
+            if (attr is not { AutoAction: not null, ReplaceSkill: not null })
+                continue;
+            if (attr.AutoAction.IsHeal != canHeal)
+                continue;
+
+            if (attr.AutoAction.IsAoE)
+            {
+                if (stOnly) continue;
+                _processAoEScratch.Add(attr);
+            }
+            else
+            {
+                _processSTScratch.Add(attr);
+            }
+        }
+
+        if (ProcessPartition(_processAoEScratch)) return false;
+        ProcessPartition(_processSTScratch);
+        return false;
+    }
+
+    private static bool ProcessPartition(List<PresetStorage.PresetData> list)
+    {
+        foreach (var attributes in list)
+        {
             var action = attributes.AutoAction!;
 
             // Skip if locked
@@ -402,20 +438,20 @@ internal unsafe class AutoRotationController
 
             if (action.IsHeal)
             {
-                AutomateHealing(entry.Preset, attributes, gameAct);
+                AutomateHealing(attributes.Preset, attributes, gameAct);
                 continue;
             }
 
             // Tank logic
             if (Player.Object?.GetRole() is CombatRole.Tank)
             {
-                AutomateTanking(entry.Preset, attributes, gameAct);
+                AutomateTanking(attributes.Preset, attributes, gameAct);
                 continue;
             }
 
             // DPS logic
-            if (!action.IsHeal && AutomateDPS(entry.Preset, attributes, gameAct))
-                return false;
+            if (AutomateDPS(attributes.Preset, attributes, gameAct))
+                return true;
         }
 
         return false;
@@ -442,11 +478,9 @@ internal unsafe class AutoRotationController
 
         if (regenSpell != 0 && !JustUsed(regenSpell, 4) && SimpleTarget.FocusTarget != null && (!HasStatusEffect(regenBuff, out var regen, SimpleTarget.FocusTarget) || regen?.RemainingTime <= 5f))
         {
-            var query = Svc.Objects.Where(x => !x.IsDead && x.IsTargetable && x.IsHostile());
-            if (!query.Any())
+            if (!AnyHostileWithinRangeOf(SimpleTarget.FocusTarget, QueryRange))
                 return;
 
-            if (query.Min(x => GetTargetDistance(x, SimpleTarget.FocusTarget)) <= QueryRange)
             {
                 var spell = ActionManager.Instance()->GetAdjustedActionId(regenSpell).Retarget(SimpleTarget.FocusTarget);
 
@@ -506,11 +540,9 @@ internal unsafe class AutoRotationController
                 }
             }
 
-            var query = Svc.Objects.Where(x => !x.IsDead && x.IsTargetable && x.IsHostile());
-            if (!query.Any())
+            if (!AnyHostileWithinRangeOf(SimpleTarget.FocusTarget, QueryRange))
                 return;
 
-            if (query.Min(x => GetTargetDistance(x, SimpleTarget.FocusTarget)) <= QueryRange)
             {
                 var spell = ActionManager.Instance()->GetAdjustedActionId(shieldSpell).Retarget(SimpleTarget.FocusTarget);
 
@@ -661,25 +693,48 @@ internal unsafe class AutoRotationController
 
     // Note: Not entirely sure what to do when the Kardia standalone retargeting is on since it doesn't follow this ruleset so this will be untouched for now but
     // it is known if it acts funny with the standalone retarget then that's what causes it.
+    private static readonly HashSet<ulong> _kardiaTargetedScratch = new();
+
     private static void UpdateKardiaTarget()
     {
         if (HasStatusEffect(418)) return;
         if (!LevelChecked(SGE.Kardia)) return;
         if (CombatEngageDuration().TotalSeconds < 3) return;
 
-        foreach (var member in GetPartyMembers().Where(x => !x.BattleChara.IsDead).OrderByDescending(x => x.BattleChara?.GetRole() is CombatRole.Tank))
+        // Single pass: which game-object IDs are being targeted by a hostile?
+        _kardiaTargetedScratch.Clear();
+        foreach (var x in Svc.Objects)
         {
-            if (cfg.HealerSettings.KardiaTanksOnly && member.BattleChara?.GetRole() is not CombatRole.Tank &&
-                !HasStatusEffect(3615, member.BattleChara, true)) continue;
-
-            var enemiesTargeting = Svc.Objects.Count(x => x.IsTargetable && x.IsHostile() && x.TargetObjectId == member.BattleChara.GameObjectId);
-            if (enemiesTargeting > 0 && !HasStatusEffect(SGE.Buffs.Kardion, member.BattleChara))
-            {
-                ActionManager.Instance()->UseAction(ActionType.Action, SGE.Kardia.Retarget(member.BattleChara), member.BattleChara.GameObjectId);
-                return;
-            }
+            if (!x.IsTargetable || !x.IsHostile()) continue;
+            var tid = x.TargetObjectId;
+            if (tid != 0) _kardiaTargetedScratch.Add(tid);
         }
 
+        var party = GetPartyMembers();
+
+        // Tanks first, then everyone else (mirrors the old OrderByDescending(role is Tank))
+        for (int pass = 0; pass < 2; pass++)
+        {
+            bool tankPass = pass == 0;
+            for (int i = 0; i < party.Count; i++)
+            {
+                var member = party[i];
+                var bc = member.BattleChara;
+                if (bc is null || bc.IsDead) continue;
+
+                bool isTank = bc.GetRole() is CombatRole.Tank;
+                if (isTank != tankPass) continue;
+
+                if (cfg.HealerSettings.KardiaTanksOnly && !isTank && !HasStatusEffect(3615, bc, true))
+                    continue;
+
+                if (_kardiaTargetedScratch.Contains(bc.GameObjectId) && !HasStatusEffect(SGE.Buffs.Kardion, bc))
+                {
+                    ActionManager.Instance()->UseAction(ActionType.Action, SGE.Kardia.Retarget(bc), bc.GameObjectId);
+                    return;
+                }
+            }
+        }
     }
 
     private static bool AutomateDPS(Preset preset, PresetStorage.PresetData attributes, uint gameAct)
@@ -1041,9 +1096,39 @@ internal unsafe class AutoRotationController
             ((cfg.DPSSettings.OnlyAttackInCombat && chara.Struct()->InCombat) || !cfg.DPSSettings.OnlyAttackInCombat) &&
             IsInLineOfSight(chara);
 
-        public static IEnumerable<IGameObject> BaseSelection => Svc.Objects.Any(x => Query(x) && IsPriority(x))
-            ? Svc.Objects.Where(x => Query(x) && IsPriority(x))
-            : Svc.Objects.Where(x => Query(x));
+        private static long _baseSelectionTick = -1;
+        private static readonly List<IGameObject> _baseSelectionCache = new();
+        private static readonly List<IGameObject> _baseSelectionPriorityScratch = new();
+
+        public static List<IGameObject> BaseSelection
+        {
+            get
+            {
+                var tick = Environment.TickCount64;
+                if (_baseSelectionTick == tick)
+                    return _baseSelectionCache;
+
+                _baseSelectionTick = tick;
+                _baseSelectionCache.Clear();
+                _baseSelectionPriorityScratch.Clear();
+
+                foreach (var x in Svc.Objects)
+                {
+                    if (!Query(x)) continue;
+                    _baseSelectionCache.Add(x);
+                    if (IsPriority(x))
+                        _baseSelectionPriorityScratch.Add(x);
+                }
+
+                if (_baseSelectionPriorityScratch.Count > 0)
+                {
+                    _baseSelectionCache.Clear();
+                    _baseSelectionCache.AddRange(_baseSelectionPriorityScratch);
+                }
+
+                return _baseSelectionCache;
+            }
+        }
 
         private static bool IsPriority(IGameObject x)
         {

--- a/WrathCombo/Core/ActionReplacer.cs
+++ b/WrathCombo/Core/ActionReplacer.cs
@@ -37,6 +37,8 @@ internal sealed class ActionReplacer : IDisposable
 
     public readonly Dictionary<uint, uint> LastActionInvokeFor = [];
 
+    private readonly Dictionary<uint, long> _actionThrottleExpiry = [];
+
     /// <summary>
     ///     Critical for the hook, do not remove or modify.
     /// </summary>
@@ -115,9 +117,11 @@ internal sealed class ActionReplacer : IDisposable
                 return OriginalHook(actionID);
 
             // Only refresh every so often
-            if (!EzThrottler.Throttle("Actions" + actionID,
-                    Service.Configuration.Throttle))
+            var now = Environment.TickCount64;
+            if (_actionThrottleExpiry.TryGetValue(actionID, out var expiresAt) && now < expiresAt)
                 return LastActionInvokeFor[actionID];
+
+            _actionThrottleExpiry[actionID] = now + Service.Configuration.Throttle;
 
             // Actually get the action
             LastActionInvokeFor[actionID] = GetAdjustedAction(actionID);
@@ -144,8 +148,8 @@ internal sealed class ActionReplacer : IDisposable
                 Player.Object is null ||
                 !GenericHelpers.IsScreenReady() ||
                 !Svc.ClientState.IsLoggedIn ||
-                (DisabledJobsPVE.Any(x => x == Player.Job) && !Svc.ClientState.IsPvP) ||
-                (DisabledJobsPVP.Any(x => x == Player.Job) && Svc.ClientState.IsPvP))
+                (DisabledJobsPVE.Contains(Player.Job) && !Svc.ClientState.IsPvP) ||
+                (DisabledJobsPVP.Contains(Player.Job) && Svc.ClientState.IsPvP))
                 return OriginalHook(actionID);
 
             foreach (CustomCombo? combo in FilteredCombos)
@@ -210,7 +214,7 @@ internal sealed class ActionReplacer : IDisposable
 
     #region Restrict combos to current job
 
-    public static IEnumerable<CustomCombo>? FilteredCombos;
+    public static CustomCombo[]? FilteredCombos;
 
     public void UpdateFilteredCombos()
     {
@@ -229,13 +233,11 @@ internal sealed class ActionReplacer : IDisposable
             return (presetData.JobInfo.Role is JobRole role &&
                 role.MatchesPlayerJob())
                 || presetData.JobInfo.Job == upgradedJob;
-        });
-
-        var filteredCombos = FilteredCombos as CustomCombo[] ?? FilteredCombos.ToArray();
+        }).ToArray();
 
         Svc.Log.Debug(
-            $"Now running {filteredCombos.Length} combos\n" +
-            string.Join("\n", filteredCombos.Select(x => x.Preset.Attributes().Name)));
+            $"Now running {FilteredCombos.Length} combos\n" +
+            string.Join("\n", FilteredCombos.Select(x => x.Preset.Attributes().Name)));
     }
 
     #endregion

--- a/WrathCombo/CustomCombo/CustomCombo.cs
+++ b/WrathCombo/CustomCombo/CustomCombo.cs
@@ -46,7 +46,7 @@ internal abstract partial class CustomCombo : CustomComboFunctions
     ///     Without the action also being checked, the preset would block all
     ///     other presets.
     /// </remarks>
-    private readonly Dictionary<Preset, uint>
+    private static readonly Dictionary<Preset, uint>
         _presetsAllowedToReturnUnchanged = new()
         {
             { Preset.DNC_DesirablePartner, DNC.ClosedPosition },

--- a/WrathCombo/CustomCombo/Functions/Hate.cs
+++ b/WrathCombo/CustomCombo/Functions/Hate.cs
@@ -52,7 +52,7 @@ internal abstract partial class CustomComboFunctions
     {
         foreach (var dps in EnmityDictParty?.OrderByDescending(x => x.Value))
         {
-            var obj = Svc.Objects.First(x => x.GameObjectId == dps.Key) as IBattleChara;
+            var obj = Svc.Objects.SearchById(dps.Key) as IBattleChara;
             if (obj?.GetRole() is CombatRole.DPS)
                 return obj;
 

--- a/WrathCombo/CustomCombo/Functions/Party.cs
+++ b/WrathCombo/CustomCombo/Functions/Party.cs
@@ -193,8 +193,38 @@ public class WrathPartyMember
         ? realJob
         : BattleChara?.ClassJob.Value ?? ExcelJobHelper.GetJobById(0);
 
-    public IBattleChara? BattleChara => Svc.Objects.SearchById(GameObjectId) as IBattleChara;
-    public IGameObject? GameObject => Svc.Objects.SearchById(GameObjectId);
+    private long _objCacheTick = -1;
+    private IGameObject? _gameObjCache;
+    private IBattleChara? _battleCharaCache;
+
+    public IBattleChara? BattleChara
+    {
+        get
+        {
+            RefreshObjectCache();
+            return _battleCharaCache;
+        }
+    }
+
+    public IGameObject? GameObject
+    {
+        get
+        {
+            RefreshObjectCache();
+            return _gameObjCache;
+        }
+    }
+
+    private void RefreshObjectCache()
+    {
+        var tick = Environment.TickCount64;
+        if (_objCacheTick == tick)
+            return;
+
+        _objCacheTick = tick;
+        _gameObjCache = Svc.Objects.SearchById(GameObjectId);
+        _battleCharaCache = _gameObjCache as IBattleChara;
+    }
     public Dictionary<ushort, long> BuffsGainedAt = new();
 
     private uint _currentHP;

--- a/WrathCombo/CustomCombo/Functions/Target.cs
+++ b/WrathCombo/CustomCombo/Functions/Target.cs
@@ -38,7 +38,17 @@ internal abstract partial class CustomComboFunctions
     public static bool HasTarget() => CurrentTarget is not null;
 
     /// <summary> Checks if the player is being targeted by a hostile, targetable object. </summary>
-    public static bool IsPlayerTargeted() => Svc.Objects.Any(x => x.IsTargetable && x.IsHostile() && x.TargetObjectId == LocalPlayer?.GameObjectId);
+    public static bool IsPlayerTargeted()
+    {
+        if (LocalPlayer is not { } player) return false;
+        var playerId = player.GameObjectId;
+        foreach (var x in Svc.Objects)
+        {
+            if (x.IsTargetable && x.IsHostile() && x.TargetObjectId == playerId)
+                return true;
+        }
+        return false;
+    }
 
     /// <summary> Checks if an object is dead. Defaults to CurrentTarget unless specified. </summary>
     internal static bool TargetIsDead(IGameObject? optionalTarget = null) => (optionalTarget ?? CurrentTarget) is IBattleChara chara && chara.IsDead;

--- a/WrathCombo/CustomCombo/Functions/Timer.cs
+++ b/WrathCombo/CustomCombo/Functions/Timer.cs
@@ -63,31 +63,38 @@ internal abstract partial class CustomComboFunctions
         Svc.Framework.Update += CheckStatuses;
     }
 
+    private static readonly HashSet<uint> _currentStatusScratch = new();
+    private static readonly List<uint> _removedStatusScratch = new();
+
     private static void CheckStatuses(IFramework framework)
     {
         if (!Player.Available) return;
+
+        _currentStatusScratch.Clear();
         foreach (var status in LocalPlayer.StatusList)
         {
-            if (status.StatusId == 0)
-                continue;
+            if (status.StatusId == 0) continue;
+            _currentStatusScratch.Add(status.StatusId);
 
-            if (!onPlayerStatuses.Contains(status.StatusId))
-                OnStatusChanged.Invoke(status.StatusId, true);
-
-            onPlayerStatuses.Add(status.StatusId);
+            if (onPlayerStatuses.Add(status.StatusId))
+                OnStatusChanged?.Invoke(status.StatusId, true);
         }
 
         if (onPlayerStatuses.Count == 0)
             return;
 
-        var clonedList = onPlayerStatuses.ToList();
-        foreach (var status in clonedList)
+        _removedStatusScratch.Clear();
+        foreach (var statusId in onPlayerStatuses)
         {
-            if (!LocalPlayer.StatusList.Any(x => x.StatusId == status))
-            {
-                OnStatusChanged.Invoke(status, false);
-                onPlayerStatuses.Remove(status);
-            }
+            if (!_currentStatusScratch.Contains(statusId))
+                _removedStatusScratch.Add(statusId);
+        }
+
+        for (int i = 0; i < _removedStatusScratch.Count; i++)
+        {
+            var id = _removedStatusScratch[i];
+            OnStatusChanged?.Invoke(id, false);
+            onPlayerStatuses.Remove(id);
         }
     }
 
@@ -118,35 +125,55 @@ internal abstract partial class CustomComboFunctions
         }
     }
 
+    private static readonly List<ulong> _deadtionaryRemovalScratch = new();
+
     private static void UpdateDeadtionary(IFramework framework)
     {
         if (!Player.Available) return;
-        foreach (var member in DeadPeople.Where(x => x.BattleChara is not null && x.BattleChara.IsDead))
+
+        var dead = DeadPeople;
+        for (int i = 0; i < dead.Count; i++)
         {
-            if (!Deadtionary.ContainsKey(member.BattleChara.GameObjectId))
-                Deadtionary[member.BattleChara.GameObjectId] = Environment.TickCount64;
+            var bc = dead[i].BattleChara;
+            if (bc is null || !bc.IsDead) continue;
+            var id = bc.GameObjectId;
+            if (!Deadtionary.ContainsKey(id))
+                Deadtionary[id] = Environment.TickCount64;
         }
 
-        var deadCopy = Deadtionary.ToList();
-        foreach (var member in deadCopy)
+        _deadtionaryRemovalScratch.Clear();
+        foreach (var kvp in Deadtionary)
         {
-            var obj = Svc.Objects.SearchById(member.Key);
-            if (obj == null || !obj.IsDead)  // Not found OR no longer dead
-            {
-                Deadtionary.Remove(member.Key);
-            }
+            var obj = Svc.Objects.SearchById(kvp.Key);
+            if (obj == null || !obj.IsDead)
+                _deadtionaryRemovalScratch.Add(kvp.Key);
         }
+        for (int i = 0; i < _deadtionaryRemovalScratch.Count; i++)
+            Deadtionary.Remove(_deadtionaryRemovalScratch[i]);
     }
 
     private static unsafe void UpdatePartyTimer(IFramework framework)
     {
         if (!Player.Available) return;
-        if (GetPartyMembers().Any(x => x.BattleChara is not null && x.BattleChara.Struct()->InCombat) && !PartyInCombatCheck)
+
+        var members = GetPartyMembers();
+        bool anyInCombat = false;
+        for (int i = 0; i < members.Count; i++)
+        {
+            var bc = members[i].BattleChara;
+            if (bc is not null && bc.Struct()->InCombat)
+            {
+                anyInCombat = true;
+                break;
+            }
+        }
+
+        if (anyInCombat && !PartyInCombatCheck)
         {
             PartyInCombatCheck = true;
             partyCombat = DateTime.Now;
         }
-        else if (!GetPartyMembers().Any(x => x.BattleChara is not null && x.BattleChara.Struct()->InCombat))
+        else if (!anyInCombat)
         {
             PartyInCombatCheck = false;
         }

--- a/WrathCombo/Data/ActionWatching.cs
+++ b/WrathCombo/Data/ActionWatching.cs
@@ -48,9 +48,9 @@ public static class ActionWatching
     internal static readonly Dictionary<(uint, ulong), long> UsedOnDict = [];
 
     // Lists
-    internal readonly static List<uint> WeaveActions = [];
-    internal readonly static List<uint> CombatActions = [];
-    internal readonly static HashSet<uint> BossesBaseIds = [.. Svc.Data.GetExcelSheet<BNpcBase>().Where(charaSheet => charaSheet.Rank is 2 or 6).Select(charaSheet => charaSheet.RowId)];
+    internal static readonly List<uint> WeaveActions = [];
+    internal static readonly List<uint> CombatActions = [];
+    internal static readonly HashSet<uint> BossesBaseIds = [.. Svc.Data.GetExcelSheet<BNpcBase>().Where(charaSheet => charaSheet.Rank is 2 or 6).Select(charaSheet => charaSheet.RowId)];
 
     // Delegates
     public delegate void LastActionChangeDelegate();
@@ -60,10 +60,10 @@ public static class ActionWatching
     public static event ActionSendDelegate? OnActionSend;
 
     private unsafe delegate void ReceiveActionEffectDelegate(uint casterEntityId, Character* casterPtr, Vector3* targetPos, Header* header, TargetEffects* effects, GameObjectId* targetEntityIds);
-    private readonly static Hook<ReceiveActionEffectDelegate>? ReceiveActionEffectHook;
+    private static readonly Hook<ReceiveActionEffectDelegate>? ReceiveActionEffectHook;
 
     private unsafe delegate bool UseActionDelegate(ActionManager* actionManager, ActionType actionType, uint actionId, ulong targetId, uint extraParam, ActionManager.UseActionMode mode, uint comboRouteId, bool* outOptAreaTargeted);
-    private readonly static Hook<UseActionDelegate>? UseActionHook;
+    private static readonly Hook<UseActionDelegate>? UseActionHook;
 
     private delegate void SendActionDelegate(ulong targetObjectId, byte actionType, uint actionId, ushort sequence, long a5, long a6, long a7, long a8, long a9);
     private static readonly Hook<SendActionDelegate>? SendActionHook;
@@ -119,7 +119,7 @@ public static class ActionWatching
             var actionType = header->ActionType;
             var currentTick = Environment.TickCount64;
             var playerObjectId = LocalPlayer.GameObjectId;
-            var partyMembers = GetPartyMembers().ToDictionary(x => x.GameObjectId);
+            var partyMembers = GetPartyMembers();
 #if DEBUG
             var debugObjectTable = Svc.Objects;
             var debugActionName = actionId.ActionName();
@@ -149,7 +149,7 @@ public static class ActionWatching
                     var effType = eff.Type;
                     var effValue = eff.Value;
                     var effObjectId = eff.AtSource ? casterEntityId : targetId;
-                    var dataId = Svc.Objects.FirstOrDefault(x => x.GameObjectId == effObjectId)?.BaseId;
+                    var dataId = Svc.Objects.SearchById(effObjectId)?.BaseId;
 
 #if DEBUG
                     Svc.Log.Verbose(
@@ -166,7 +166,7 @@ public static class ActionWatching
                     // Event: Heal or Damage
                     if (effType is ActionEffectType.Heal or ActionEffectType.Damage)
                     {
-                        if (partyMembers.TryGetValue(targetId, out var member))
+                        if (FindPartyMember(partyMembers, targetId) is { } member)
                         {
                             member.CurrentHP = effType == ActionEffectType.Damage
                                 ? Math.Min(member.BattleChara.MaxHp, member.CurrentHP - effValue)
@@ -180,7 +180,7 @@ public static class ActionWatching
                     // Event: MP Gain or MP Loss
                     if (effType is ActionEffectType.MpGain or ActionEffectType.MpLoss)
                     {
-                        if (partyMembers.TryGetValue(effObjectId, out var member))
+                        if (FindPartyMember(partyMembers, effObjectId) is { } member)
                         {
                             member.CurrentMP = effType == ActionEffectType.MpLoss
                                 ? Math.Min(member.BattleChara.MaxMp, member.CurrentMP - effValue)
@@ -194,7 +194,7 @@ public static class ActionWatching
                     // Event: Status Gain (Source)
                     if (effType is ActionEffectType.ApplyStatusEffectSource)
                     {
-                        if (partyMembers.TryGetValue(effObjectId, out var member))
+                        if (FindPartyMember(partyMembers, effObjectId) is { } member)
                         {
                             member.BuffsGainedAt[effValue] = currentTick;
                         }
@@ -206,10 +206,8 @@ public static class ActionWatching
                         if (ICDTracker.Trackers.TryGetFirst(x => x.StatusID == effValue && x.GameObjectId == effObjectId, out var icd))
                         {
                             //This section here is just to clear out any erroneous times a status was added to the blacklist when it shouldn't have due to potential timings
-                            if (dataId is uint val && Service.Configuration.StatusBlacklist.Any(x => x.Status == effValue && x.BaseId == dataId))
+                            if (dataId is uint val && Service.Configuration.StatusBlacklist.Remove((effValue, val)))
                             {
-                                var p = Service.Configuration.StatusBlacklist.First(x => x.Status == effValue && x.BaseId == dataId);
-                                Service.Configuration.StatusBlacklist.Remove(p);
                                 Service.Configuration.Save();
                             }
                             icd.ICDClearedTime = dateNow + TimeSpan.FromSeconds(60);
@@ -242,6 +240,16 @@ public static class ActionWatching
         {
             Svc.Log.Error(ex, "ReceiveActionEffectDetour");
         }
+    }
+
+    private static WrathPartyMember? FindPartyMember(List<WrathPartyMember> members, ulong gameObjectId)
+    {
+        for (int i = 0; i < members.Count; i++)
+        {
+            if (members[i].GameObjectId == gameObjectId)
+                return members[i];
+        }
+        return null;
     }
 
     private static unsafe void UpdateLastUsedAction(uint actionId, byte actionType, ulong targetObjectId, int castTime)
@@ -457,7 +465,7 @@ public static class ActionWatching
                 }
 
                 // Clear any dodgy leftover targets
-                if (!Svc.Objects.Any(x => x.GameObjectId == actionManager->QueuedTargetId.Id))
+                if (Svc.Objects.SearchById(actionManager->QueuedTargetId.Id) is null)
                     actionManager->QueuedTargetId = 0;
 
                 // However, if we have a queued target ID assume that's what we want and not whatever current retargeting is. TODO: Setting?

--- a/WrathCombo/Data/StatusCache.cs
+++ b/WrathCombo/Data/StatusCache.cs
@@ -96,6 +96,10 @@ internal class StatusCache
 
     public static bool HasDamageUp(IGameObject? target) => HasStatusInCacheList(DamageUpStatuses, target);
 
+    // TODO: this is a copy-paste of DamageUpStatuses — both reference status ID 61 ("Damage Up")
+    // and match by name. HasEvasionUp is therefore identical to HasDamageUp, making the
+    // `HasDamageUp(target) || HasEvasionUp(target)` check in HasPhantomDispelStatus redundant.
+    // Replace 61 with the correct Evasion Up reference status ID (or change the name match).
     private static readonly FrozenSet<uint> evasionUpStatuses =
         ENStatusSheet.TryGetValue(61, out var refRow)
             ? ENStatusSheet
@@ -206,28 +210,31 @@ internal class StatusCache
     /// <returns></returns>
     internal static bool HasStatusInCacheList(FrozenSet<uint> statusList, IGameObject? gameObject = null)
     {
-        if (gameObject is not IBattleChara chara)
+        if (statusList.Count == 0 || gameObject is not IBattleChara chara)
             return false;
 
         var statuses = chara.SafeStatusList;
-
         if (statuses is null)
             return false;
 
-        var targetStatuses = statuses.Select(s => s.StatusId).ToHashSet();
-        return statusList.Count switch
+        foreach (var status in statuses)
         {
-            0 => false,
-            _ => CompareLists(statusList, targetStatuses)
-        };
+            if (statusList.Contains(status.StatusId))
+                return true;
+        }
+        return false;
     }
 
     /// <summary>
     /// Compares two hashsets, in this case, used to compare a cached set of status IDs against a character's StatusID list
     /// </summary>
-    /// <param name="statusList"></param>
-    /// <param name="charaStatusList"></param>
-    /// <returns></returns>
-    internal static bool CompareLists(FrozenSet<uint> statusList, HashSet<uint> charaStatusList) =>
-        charaStatusList.Any(id => statusList.Contains(id));
+    internal static bool CompareLists(FrozenSet<uint> statusList, HashSet<uint> charaStatusList)
+    {
+        foreach (var id in charaStatusList)
+        {
+            if (statusList.Contains(id))
+                return true;
+        }
+        return false;
+    }
 }

--- a/WrathCombo/Services/IPC/Helper.cs
+++ b/WrathCombo/Services/IPC/Helper.cs
@@ -79,7 +79,6 @@ public partial class Helper(ref Leasing leasing)
     /// <returns>The Opposite-mode preset.</returns>
     internal static Preset? GetOppositeModeCombo(Preset preset)
     {
-        const StringComparison lower = StringComparison.CurrentCultureIgnoreCase;
         var presetData = preset.Attributes();
 
         // Bail if it is not one of the main combos

--- a/WrathCombo/Window/Functions/Setting.cs
+++ b/WrathCombo/Window/Functions/Setting.cs
@@ -31,6 +31,7 @@ public class Setting
         if (CachedSettings.TryGetValue(settingName, out var cachedSetting))
         {
             Category              = cachedSetting.Category;
+            CategoryName          = cachedSetting.CategoryName;
             Name                  = cachedSetting.Name;
             HelpMark              = cachedSetting.HelpMark;
             RecommendedValue      = cachedSetting.RecommendedValue;

--- a/WrathCombo/WrathCombo.cs
+++ b/WrathCombo/WrathCombo.cs
@@ -353,31 +353,17 @@ public sealed partial class WrathCombo : IDalamudPlugin
             // Skip the IPC checking if hidden
             if (!DtrBarEntry.UserHidden)
             {
-                #region DTR Bar Updating
-
-                var autoOn = IPC.GetAutoRotationState();
-                var icon = new IconPayload(autoOn
-                    ? BitmapFontIcon.SwordUnsheathed
-                    : BitmapFontIcon.SwordSheathed);
-
-                var text = autoOn ? ": On" : ": Off";
-                if (!Service.Configuration.ShortDTRText && autoOn)
-                    text += $" ({P.IPCSearch.ActiveJobPresets} active)";
-                var ipcControlledText =
-                    P.UIHelper.AutoRotationStateControlled() is not null
-                        ? " (Locked)"
-                        : "";
-
-                var payloadText = new TextPayload(text + ipcControlledText);
-                DtrBarEntry.Text = new SeString(icon, payloadText);
-
-                #endregion
+                UpdateAutoRotDtr();
             }
 
             if (Service.Configuration.ShowOpenerDtr)
             {
-                var status = new TextPayload(WrathOpener.OpenerStatus());
-                OpenerDtr.Text = new SeString(status);
+                var status = WrathOpener.OpenerStatus();
+                if (status != _lastOpenerStatus)
+                {
+                    _lastOpenerStatus = status;
+                    OpenerDtr.Text = new SeString(new TextPayload(status));
+                }
                 OpenerDtr.Shown = true;
             }
             else
@@ -393,6 +379,47 @@ public sealed partial class WrathCombo : IDalamudPlugin
         {
             ex.Log("Pls no crash game ty");
         }
+    }
+
+    // Cached DTR state — only rebuild SeStrings on actual change.
+    private bool _dtrInitialized;
+    private bool _lastAutoOn;
+    private bool _lastShortDtrText;
+    private int _lastActiveJobPresets;
+    private bool _lastDtrLocked;
+    private string? _lastOpenerStatus;
+
+    private void UpdateAutoRotDtr()
+    {
+        var autoOn = IPC.GetAutoRotationState();
+        var shortText = Service.Configuration.ShortDTRText;
+        var activePresets = P.IPCSearch.ActiveJobPresets;
+        var locked = P.UIHelper.AutoRotationStateControlled() is not null;
+
+        if (_dtrInitialized &&
+            _lastAutoOn == autoOn &&
+            _lastShortDtrText == shortText &&
+            _lastActiveJobPresets == activePresets &&
+            _lastDtrLocked == locked)
+            return;
+
+        _dtrInitialized = true;
+        _lastAutoOn = autoOn;
+        _lastShortDtrText = shortText;
+        _lastActiveJobPresets = activePresets;
+        _lastDtrLocked = locked;
+
+        var icon = new IconPayload(autoOn
+            ? BitmapFontIcon.SwordUnsheathed
+            : BitmapFontIcon.SwordSheathed);
+
+        var text = autoOn ? ": On" : ": Off";
+        if (!shortText && autoOn)
+            text += $" ({activePresets} active)";
+        if (locked)
+            text += " (Locked)";
+
+        DtrBarEntry.Text = new SeString(icon, new TextPayload(text));
     }
 
     private static void ResetFeatures()


### PR DESCRIPTION
**Action hook**
- `FilteredCombos` is now an array instead of an unmaterialized `IEnumerable` — was re-running the `Where` filter over ~200 combos on every single hook call
- Swapped the `"Actions" + id` string-concat throttle key + `EzThrottler` lookup for a plain `Dictionary<uint, long>`
- A few `.Any(x => x == ...)` → `.Contains`, and rewrote `IsPlayerTargeted` as a foreach so it doesn't allocate a closure

**Autorotation tick**
- `BaseSelection` is now cached for the tick and built in a single pass. It was doing `Any` then `Where` and getting called 7 times per tick from the targeting methods
- Tore out the `Select/Where×3/OrderByDescending` chain in `ProcessAutoActions` and replaced it with a single foreach into two reusable scratch lists
- `cfg.DPSSettings` / `cfg.HealerSettings` were allocating a new wrapper on every property read — now lazy-cached
- `WrathPartyMember.BattleChara` was calling `Svc.Objects.SearchById` on every access. Healer queries hit it 4-6 times per member, so now it caches for the current tick
- `UpdateKardiaTarget` was doing `Svc.Objects.Count(...)` inside the party foreach — that's O(party × all game objects). Now pre-builds a `HashSet` of targeted IDs once and looks up in there
- `PreEmptiveHot`/`PreEmptiveShield` were iterating `Svc.Objects` twice (Any then Min). Collapsed into one helper

**Per-frame**
- `Timer.CheckStatuses` was allocating `onPlayerStatuses.ToList()` plus a nested `.Any(lambda)` every frame. Now uses reusable scratch sets
- Same kind of thing in `UpdateDeadtionary` (`Where`/`ToList` every frame) and `UpdatePartyTimer` (calling `GetPartyMembers().Any(closure)` twice with the same predicate)
- The DTR bar was rebuilding the `SeString` from scratch every frame regardless of whether anything had changed — now only rebuilds when one of the inputs actually changes

**Other**
- `StatusCache.HasStatusInCacheList` was allocating a `HashSet` per call to do a containment check — replaced with a foreach
- `CustomCombo._presetsAllowedToReturnUnchanged` was an instance field, so every combo subclass (~200 of them) carried its own copy of the same 1-entry dictionary. Made it `static readonly`
- In `ActionWatching`: dropped the per-effect `ToDictionary` of party members; swapped a couple `Svc.Objects.FirstOrDefault(lambda)`/`Any(lambda)` for `SearchById`; the `StatusBlacklist` cleanup was doing `Any` then `First` (two linear scans) where a single `HashSet.Remove` works

- `StatusCache.evasionUpStatuses` is a copy-paste of `DamageUpStatuses` — both pull status ID 61 ("Damage Up") and match by name. So `HasEvasionUp` is currently identical to `HasDamageUp`, which makes the `||` in `HasPhantomDispelStatus` redundant. Didn't want to guess at the correct Evasion Up reference, so I left a TODO.
